### PR TITLE
Replace null-strings with empty strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Engelsystem changelog
 
+## NEXT
+
+* Published: yyyy-mm-dd
+
+### Changes
+
+* Replace null-strings with empty strings.
+
+
 ## [v.1.0.0](https://github.com/johnjohndoe/engelsystem/releases/tag/v.1.0.0)
 
 * Published: 2019-12-07

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
@@ -28,7 +28,7 @@ data class Shift(
      * Description of the shift location.
      */
     @Json(name = "description")
-    val locationDescription: String = "",
+    internal val locationDescriptionString: String? = "",
 
     /**
      * Name of the location where the shift takes place.
@@ -40,7 +40,7 @@ data class Shift(
      * Link to the location of the shift.
      */
     @Json(name = "map_url")
-    val locationUrl: String = "",
+    internal val locationUrlString: String? = "",
 
     /**
      * Name of the shift.
@@ -70,7 +70,7 @@ data class Shift(
      * Link of the associated talk in case the shift happens at a talk.
      */
     @Json(name = "URL")
-    val talkUrl: String? = "",
+    internal val talkUrlString: String? = "",
 
     /**
      * Shift types ids are not fixed. They can be assigned whenever an instance of the Engelsystem is launched.
@@ -83,5 +83,23 @@ data class Shift(
     companion object {
         internal val DEFAULT_DATE_TIME = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
     }
+
+    /**
+     * Description of the shift location.
+     */
+    val locationDescription: String
+        get() = locationDescriptionString ?: ""
+
+    /**
+     * Link to the location of the shift.
+     */
+    val locationUrl: String
+        get() = locationUrlString ?: ""
+
+    /**
+     * Link of the associated talk in case the shift happens at a talk.
+     */
+    val talkUrl: String
+        get() = talkUrlString ?: ""
 
 }

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
@@ -44,9 +44,7 @@ class ProductionApiTest {
         assertThat(shift.locationDescription).isNotNull()
         assertThat(shift.locationUrl).isNotNull()
         assertThat(shift.talkTitle).isNotNull()
-        shift.talkUrl?.let {
-            assertThat(it).isNotEmpty()
-        }
+        assertThat(shift.talkUrl).isNotNull()
         assertThat(shift.userComment).isNotNull()
         assertThat(shift.startsAt).isNotEqualTo(Shift.DEFAULT_DATE_TIME)
         assertThat(shift.endsAt).isNotEqualTo(Shift.DEFAULT_DATE_TIME)


### PR DESCRIPTION
As shown in this response excerpt, some properties can be `null`:

``` json
{
    "Comment": "",
    "Name": "Kourou",
    "RID": 13,
    "SID": 627,
    "TID": 6,
    "UID": 32,
    "URL": null,
    "created_at_timestamp": 1575838846,
    "created_by_user_id": 32,
    "description": null,
    "edited_at_timestamp": 1575916614,
    "edited_by_user_id": 32,
    "end": 1577440800,
    "freeloaded": 0,
    "id": 54,
    "map_url": null,
    "name": "Collect pandas",
    "shifttype_id": 6,
    "start": 1577437200,
    "timezone": "+01:00",
    "title": "Collect them all"
}
```

To avoid exposing `null` values they are replaced with empty strings.