### PR TITLE
Remove "UserAgentInterceptor" from public API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* Remove `UserAgentInterceptor` from public API.
 * Replace unneeded `kotlin-coroutines-retrofit` with `kotlinx-coroutines`.
 * Use moshi v.1.9.3.
 * Use kotlin v.1.3.72.

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/utils/UserAgentInterceptor.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/utils/UserAgentInterceptor.kt
@@ -5,7 +5,7 @@ import okhttp3.Interceptor.Chain
 import okhttp3.Response
 import java.io.IOException
 
-class UserAgentInterceptor(private val userAgent: String) : Interceptor {
+internal class UserAgentInterceptor(private val userAgent: String) : Interceptor {
 
     @Throws(IOException::class)
     override fun intercept(chain: Chain): Response {


### PR DESCRIPTION
+ Exposing the class was not intended.

Resolves #4.