### PR TITLE
Use Dokka to generate JavaDoc artifact.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     dependencies {
         classpath GradlePlugins.bintray
+        classpath GradlePlugins.dokka
         classpath GradlePlugins.kotlin
         classpath GradlePlugins.versions
     }

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Dependencies.kt
@@ -6,11 +6,13 @@ object GradlePlugins {
 
     private object Versions {
         const val bintray = "1.8.5"
+        const val dokka = "1.4.30"
         const val kotlin = "1.4.31"
         const val versions = "0.36.0"
     }
 
     const val bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Versions.bintray}"
+    const val dokka = "org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val versions = "com.github.ben-manes:gradle-versions-plugin:${Versions.versions}"
 }

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,19 +1,38 @@
 apply plugin: "java"
 apply plugin: "maven-publish"
+apply plugin: "org.jetbrains.dokka"
 
 group = project.groupId
 version = project.versionName
 
 java {
     withSourcesJar()
-    withJavadocJar()
 }
 
-javadoc {
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption("html5", true)
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+    group "publishing"
+    description "Generates javadocJar based on Dokka"
+    archiveClassifier.set("javadoc")
+    from dokkaJavadoc.outputDirectory
+}
+
+dokkaJavadoc.configure {
+    moduleName.set("Engelsystem")
+    dokkaSourceSets {
+        named("main") {
+            sourceLink {
+                localDirectory.set(file("engelsystem-base/src/main/kotlin"))
+                remoteUrl.set(java.net.URL("https://github.com/johnjohndoe/engelsystem/blob/master/engelsystem-base/src/main/kotlin"))
+                remoteLineSuffix.set("#L")
+            }
+        }
     }
 }
+
+artifacts {
+    archives javadocJar
+}
+
 
 publishing {
     publications {


### PR DESCRIPTION
+ https://kotlin.github.io/dokka/
+ Before the _engelsystem-base-version-javadoc.jar_ was empty. This outputs an archive which actually contains the generated documentation.
+ Since this was broken since version 1.0.0 there are separate dokka-branches for each version respectively. These won't get merged.