### PR TITLE
Configure MavenCentral deployment & signing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,22 @@ versionName=5.0.0
 versionDescription=Update kotlin, moshi and threetenbp.
 versionVcsTag=v.5.0.0
 # Artifact information
+artifactId=engelsystem-base
 groupId=info.metadude.kotlin.library.engelsystem
 # Package information
-packageRepository=maven
 packageName=engelsystem
 packageDescription=A Kotlin library containing a parser and models for the Engelsystem.
 packageWebsiteUrl=https://github.com/johnjohndoe/engelsystem
-packageIssueTrackingUrl=https://github.com/johnjohndoe/engelsystem/issues
-packageVcsUrl=https://github.com/johnjohndoe/engelsystem.git
-packageLicenses=["Apache-2.0"]
-packageLabels=["engelsystem", "ccc", "kotlin", "retrofit", "okhttp", "parser", "api"]
+packageScmConnection=https://github.com/johnjohndoe/engelsystem.git
+packageScmDeveloperConnection=scm:git:ssh://github.com/johnjohndoe/engelsystem.git
+packageLicenseApacheName=The Apache License, Version 2.0
+packageLicenseApacheUrl=https://github.com/Umweltzone/roadsigns/LICENSE.txt
+packageDeveloperId=johnjohndoe
+packageDeveloperName=Tobias Preuss
+packageDeveloperEmail=tobias.preuss@googlemail.com
+# MavenCentral
+mavenCentralPublicationName=MavenCentral
+# Dummy properties so that anyone can compile the library
+sonatypeRepo=""
+sonatypeUserName=""
+sonatypePassword=""

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,12 +1,17 @@
 apply plugin: "java"
+apply plugin: "signing"
 apply plugin: "maven-publish"
 apply plugin: "org.jetbrains.dokka"
 
+// javadocJar and sourcesJar tasks pick up group and version
 group = project.groupId
 version = project.versionName
 
-java {
-    withSourcesJar()
+task sourcesJar(type: Jar) {
+    group "publishing"
+    description "Generates source jar"
+    archiveClassifier.set("sources")
+    from kotlin.sourceSets.main.kotlin.srcDirs
 }
 
 task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
@@ -33,53 +38,70 @@ artifacts {
     archives javadocJar
 }
 
-
-publishing {
-    publications {
-        bintray(MavenPublication) {
-            from components.java
-            groupId project.groupId
-            artifactId moduleArtifactId
-            version = project.versionName
-        }
-    }
-}
-
-apply plugin: "com.jfrog.bintray"
-
 Properties properties = new Properties()
 def propertiesFile = project.rootProject.file("${System.properties['user.home']}/.gradle/gradle.properties")
 if (propertiesFile.exists()) {
     properties.load(propertiesFile.newDataInputStream())
 }
-def bintrayUser = properties.getProperty("bintrayUser") ?: System.getenv("BINTRAY_USER")
-def bintrayApiKey = properties.getProperty("bintrayApiKey") ?: System.getenv("BINTRAY_API_KEY")
+def mavenCentralUrl = properties.getProperty("sonatypeRepo") ?: project.sonatypeRepo
+def mavenCentralUserName = properties.getProperty("sonatypeUserName") ?: project.sonatypeUserName
+def mavenCentralPassword = properties.getProperty("sonatypePassword") ?: project.sonatypePassword
 
-bintray {
-    user = bintrayUser
-    key = bintrayApiKey
-    configurations = ["archives"]
-    publications = ["bintray"]
-    override = true
-    publish = false
-    dryRun = false
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.java
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.versionName
 
-    pkg {
-        repo = project.packageRepository
-        name = project.packageName
-        desc = project.packageDescription
-        websiteUrl = project.packageWebsiteUrl
-        issueTrackerUrl = project.packageIssueTrackingUrl
-        vcsUrl = project.packageVcsUrl
-        licenses = project.packageLicenses
-        labels = project.packageLabels
-        publicDownloadNumbers = true
+                artifact sourcesJar {
+                    classifier "sources"
+                }
 
-        version {
-            name = project.versionName
-            desc = project.versionDescription
-            released = new Date()
-            vcsTag = project.versionVcsTag
+                artifact javadocJar {
+                    classifier "javadoc"
+                }
+
+                pom {
+                    name = project.packageName
+                    description = project.packageDescription
+                    url = project.packageWebsiteUrl
+                    licenses {
+                        license {
+                            name = project.packageLicenseApacheName
+                            url = project.packageLicenseApacheUrl
+                        }
+                    }
+                    scm {
+                        connection = project.packageScmConnection
+                        developerConnection = project.packageScmDeveloperConnection
+                        url = project.packageWebsiteUrl
+                    }
+                    developers {
+                        developer {
+                            id = packageDeveloperId
+                            name = packageDeveloperName
+                            email = packageDeveloperEmail
+                        }
+                    }
+                }
+
+                repositories {
+                    maven {
+                        name project.mavenCentralPublicationName
+                        url = uri(mavenCentralUrl)
+                        credentials {
+                            username = mavenCentralUserName
+                            password = mavenCentralPassword
+                        }
+                    }
+                }
+            }
         }
+    }
+    signing {
+        sign publishing.publications.release
     }
 }


### PR DESCRIPTION
+ Replace Bintray deployment with MavenCentral.
+ Configure signing for MavenCentral deployment.
+ RIP jCenter/Bintray.
+ Library artifacts until v.5.0.0 have been pushed to MavenCentral including subsequently generated JavaDoc artifacts.