### PR TITLE
Ease dependency injection for projects using this library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+* Introduce `EngelsystemApi` interface to ease dependency injection for projects using this library.
+  * Remove `@JvmStatic` from `ApiModule#provideEngelsystemService` (only affects Java usage).
 * Use kotlin v.1.6.21 and ksp v.1.6.21-1.0.5.
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A Kotlin library containing a parser and models for the Engelsystem:
 ## Usage
 
 ```kotlin
-ApiModule.provideEngelsystemService(BASE_URL, okHttpClient)
+val engelsystemApi: EngelsystemApi = ApiModule
+engelsystemApi.provideEngelsystemService(BASE_URL, okHttpClient)
          .getShifts(URL_PART_PATH, API_KEY)
 ```
 

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/ApiModule.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/ApiModule.kt
@@ -11,10 +11,9 @@ import org.threeten.bp.ZonedDateTime
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-object ApiModule {
+object ApiModule : EngelsystemApi {
 
-    @JvmStatic
-    fun provideEngelsystemService(
+    override fun provideEngelsystemService(
         baseUrl: String,
         okHttpClient: OkHttpClient
     ): EngelsystemService {

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemApi.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemApi.kt
@@ -1,0 +1,12 @@
+package info.metadude.kotlin.library.engelsystem
+
+import okhttp3.OkHttpClient
+
+interface EngelsystemApi {
+
+    fun provideEngelsystemService(
+        baseUrl: String,
+        okHttpClient: OkHttpClient
+    ): EngelsystemService
+
+}


### PR DESCRIPTION
+ Remove `@JvmStatic` from `ApiModule#provideEngelsystemService` (only affects Java usage).