### PR TITLE
Adapt new shift type API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* **Breaking change:** Remove `name` in favor of `typeName` property for the sake of its clearer name.
 * Add new `typeName` and `typeDescription` properties to `Shift` model. See: https://github.com/engelsystem/engelsystem/pull/1233.
 * Replace `Comment` with new clearer named `user_comment` JSON property. Both expose the same value.
 * Use kotlin v.1.9.10 and ksp v.1.9.10-1.0.13 & dokka v.1.9.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* Add new `typeName` and `typeDescription` properties to `Shift` model. See: https://github.com/engelsystem/engelsystem/pull/1233.
 * Replace `Comment` with new clearer named `user_comment` JSON property. Both expose the same value.
 * Use kotlin v.1.9.10 and ksp v.1.9.10-1.0.13 & dokka v.1.9.10.
 * Use okhttp 4.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* Replace `Comment` with new clearer named `user_comment` JSON property. Both expose the same value.
 * Use kotlin v.1.9.10 and ksp v.1.9.10-1.0.13 & dokka v.1.9.10.
 * Use okhttp 4.12.0
 

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
@@ -14,9 +14,9 @@ import org.threeten.bp.ZonedDateTime
 data class Shift internal constructor(
 
     /**
-     * Private comment only visible to the associated user.
+     * Private comment only visible to the associated user. Plain text formatted.
      */
-    @Json(name = "Comment")
+    @Json(name = "user_comment")
     val userComment: String = "",
 
     /**

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
@@ -55,12 +55,6 @@ data class Shift internal constructor(
     internal val locationUrlString: String? = "",
 
     /**
-     * Name of the shift.
-     */
-    @Json(name = "name")
-    val name: String = "",
-
-    /**
      * ID of the shift.
      */
     @Json(name = "SID")
@@ -138,7 +132,6 @@ data class Shift internal constructor(
         locationDescription: String = "",
         locationName: String = "",
         locationUrl: String = "",
-        name: String = "",
         sID: Int = 0,
         startsAt: ZonedDateTime = DEFAULT_ZONED_DATE_TIME,
         startsAtDate: ZonedDateTime = DEFAULT_ZONED_DATE_TIME,
@@ -156,7 +149,6 @@ data class Shift internal constructor(
         locationDescriptionString = locationDescription,
         locationName = locationName,
         locationUrlString = locationUrl,
-        name = name,
         sID = sID,
         startsAtDate = startsAtDate,
         startsAtInstant = startsAt.toInstant(),

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/models/Shift.kt
@@ -112,10 +112,22 @@ data class Shift internal constructor(
     val timeZoneName: String,
 
     /**
+     * Textual description of the shift type. Markdown formatted.
+     */
+    @Json(name = "shifttype_description")
+    val typeDescription: String = "",
+
+    /**
      * Shift types ids are not fixed. They can be assigned whenever an instance of the Engelsystem is launched.
      */
     @Json(name = "shifttype_id")
-    val typeId: Int = 0
+    val typeId: Int = 0,
+
+    /**
+     * Textual name of the shift type.
+     */
+    @Json(name = "shifttype_name")
+    val typeName: String = "",
 
 ) {
 
@@ -134,7 +146,9 @@ data class Shift internal constructor(
         talkUrl: String = "",
         timeZoneName: String = "",
         timeZoneOffset: ZoneOffset = DEFAULT_ZONE_OFFSET,
-        typeId: Int = 0
+        typeDescription: String = "",
+        typeId: Int = 0,
+        typeName: String = ""
     ) : this(
         userComment = userComment,
         endsAtDate = endsAtDate,
@@ -150,7 +164,9 @@ data class Shift internal constructor(
         talkUrlString = talkUrl,
         timeZoneName = timeZoneName,
         timeZoneOffset = timeZoneOffset,
-        typeId = typeId
+        typeDescription = typeDescription,
+        typeId = typeId,
+        typeName = typeName
     )
 
     companion object {

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
@@ -37,7 +37,9 @@ class ProductionApiTest {
 
     private fun assertShift(shift: Shift) {
         assertThat(shift.sID).isGreaterThan(0)
+        assertThat(shift.typeDescription).isNotNull()
         assertThat(shift.typeId).isGreaterThan(0)
+        assertThat(shift.typeName).isNotEmpty()
         assertThat(shift.name).isNotEmpty()
         assertThat(shift.locationName).isNotEmpty()
         assertThat(shift.locationDescription).isNotNull()

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
@@ -40,7 +40,6 @@ class ProductionApiTest {
         assertThat(shift.typeDescription).isNotNull()
         assertThat(shift.typeId).isGreaterThan(0)
         assertThat(shift.typeName).isNotEmpty()
-        assertThat(shift.name).isNotEmpty()
         assertThat(shift.locationName).isNotEmpty()
         assertThat(shift.locationDescription).isNotNull()
         assertThat(shift.locationUrl).isNotNull()

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/models/ShiftTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/models/ShiftTest.kt
@@ -20,7 +20,10 @@ class ShiftTest {
                 startsAtDate = startsAt,
                 talkUrl = "https://example2.com",
                 timeZoneName = "Europe/Berlin",
-                timeZoneOffset = ZoneOffset.UTC
+                timeZoneOffset = ZoneOffset.UTC,
+                typeDescription = "Textual description of the shift type",
+                typeId = 42,
+                typeName = "Name of the shift type",
             )
         ).isNotNull()
     }


### PR DESCRIPTION
# Context
- The shift type description provides general information about the kind of work. Only shift specific information are contained in the (location) description of a shift to avoid repetition and ease maintenance in the Engelsystem backend. Hence, the (location) description would not provide enough information by itself.

# Description
- Replace `Comment` with new clearer named `user_comment` JSON property.
  + Both expose the same value.
  + Reference: [FeedController.php](https://github.com/engelsystem/engelsystem/blob/a31534d9b76b1e51786d06ee76c90cf97b5a1236/src/Controllers/FeedController.php#L85)
- Add new `typeName` and `typeDescription` properties to Shift model.
  + Related: https://github.com/engelsystem/engelsystem/pull/1233.
- Remove `name` in favor of `typeName` property for the sake of its clearer name.
  + Both expose the same value.