### PR TITLE
Build with JVM target 11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* **Breaking change:** Build with JVM target 11.
 * **Breaking change:** Remove `name` in favor of `typeName` property for the sake of its clearer name.
 * Add new `typeName` and `typeDescription` properties to `Shift` model. See: https://github.com/engelsystem/engelsystem/pull/1233.
 * Replace `Comment` with new clearer named `user_comment` JSON property. Both expose the same value.

--- a/engelsystem-base/build.gradle
+++ b/engelsystem-base/build.gradle
@@ -1,6 +1,7 @@
 import info.metadude.kotlin.library.engelsystem.Libs
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: "java-library"
 apply plugin: "kotlin"
@@ -9,6 +10,12 @@ apply plugin: "com.google.devtools.ksp"
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType(KotlinCompile.class).configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11
+    }
 }
 
 dependencies {


### PR DESCRIPTION
+ Before `file Shift.class` returns: `compiled Java class data, version 52.0 (Java 1.8)`
+ After `file Shift.class` returns: `compiled Java class data, version 55.0 (Java SE 11)`