### PR TITLE
Make raw response accessible to distinguish between cache or server response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Engelsystem changelog
 
+## NEXT
+
+* Not published yet.
+
+### Changes
+
+* **Breaking change:** Make raw response accessible to distinguish between cache or server response. Change `getShifts()` return type from `List<Shift>` to `Response<List<Shift>>`.
+
+
 ## [v.8.0.0](https://github.com/johnjohndoe/engelsystem/releases/tag/v.8.0.0)
 
 * Published: 2023-11-22

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemService.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemService.kt
@@ -1,6 +1,7 @@
 package info.metadude.kotlin.library.engelsystem
 
 import info.metadude.kotlin.library.engelsystem.models.Shift
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -11,6 +12,6 @@ interface EngelsystemService {
     suspend fun getShifts(
         @Path("path", encoded = true) path: String,
         @Query("key") apiKey: String
-    ): List<Shift>
+    ): Response<List<Shift>>
 
 }


### PR DESCRIPTION
# Description
+ Change `getShifts()` return type from `List<Shift>` to `Response<List<Shift>>`.
+ See: https://futurestud.io/tutorials/retrofit-2-check-response-origin-network-cache-or-both