### PR TITLE
Support sending and retrieving caching headers in requests/responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Changes
 
+* **Breaking changes:** Let `EngelsystemService#getShifts` return `Response<List<Shift>>`.
+  * Add `eTag` and `lastModifiedAt` parameters.
+  * Expose `retrofit2.Response` in library API.
 * **Breaking changes:**
   * Rename `ApiModule` to `Api`.
   * Change `Api#provideEngelsystemService` parameter from `okHttpClient: OkHttpClient` to `callFactory: Call.Factory`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changes
 
+* **Breaking changes:**
+  * Rename `ApiModule` to `Api`.
+  * Change `Api#provideEngelsystemService` parameter from `okHttpClient: OkHttpClient` to `callFactory: Call.Factory`.
+  * Require `baseUrl` parameter in `Api#provideEngelsystemService` not to be empty string.
 * Use dokka v.2.0.0.
 * Use kotlin v.2.1.20 and ksp v.2.1.20-2.0.1.
 * Use kotlinx-coroutines-test v.1.10.2.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Kotlin library containing a parser and models for the Engelsystem:
 ## Usage
 
 ```kotlin
-val engelsystemApi: EngelsystemApi = ApiModule
+val engelsystemApi: EngelsystemApi = Api
 engelsystemApi.provideEngelsystemService(BASE_URL, okHttpClient)
          .getShifts(URL_PART_PATH, API_KEY)
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ A Kotlin library containing a parser and models for the Engelsystem:
 ```kotlin
 val engelsystemApi: EngelsystemApi = Api
 engelsystemApi.provideEngelsystemService(BASE_URL, okHttpClient)
-         .getShifts(URL_PART_PATH, API_KEY)
+         .getShifts(
+             eTag = "", // Pass an empty string or a previous ETag value for caching
+             lastModifiedAt = "", // Pass an empty string or a previous Last-Modified value for caching
+             path = URL_PART_PATH, 
+             apiKey = API_KEY,
+         )
 ```
 
 

--- a/buildSrc/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Dependencies.kt
@@ -33,6 +33,7 @@ object Libs {
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitJupiter}"
     const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitJupiter}"
     const val junitPlatformLauncher = "org.junit.platform:junit-platform-launcher:${Versions.junitPlatformLauncher}"
+    const val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"
     const val moshi = "com.squareup.moshi:moshi:${Versions.moshi}"
     const val moshiKotlinCodegen = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}"

--- a/engelsystem-base/build.gradle
+++ b/engelsystem-base/build.gradle
@@ -20,11 +20,12 @@ tasks.withType(KotlinCompile).configureEach {
 }
 
 dependencies {
+    implementation Libs.kotlinCoroutinesCore
     implementation Libs.moshi
     ksp Libs.moshiKotlinCodegen
     implementation Libs.okhttp
     implementation Libs.okhttpLoggingInterceptor
-    implementation Libs.retrofit
+    api Libs.retrofit
     implementation Libs.retrofitMoshi
     api Libs.threetenbp
 

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Api.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/Api.kt
@@ -4,29 +4,30 @@ import com.squareup.moshi.Moshi
 import info.metadude.kotlin.library.engelsystem.adapters.InstantJsonAdapter
 import info.metadude.kotlin.library.engelsystem.adapters.ZoneOffsetJsonAdapter
 import info.metadude.kotlin.library.engelsystem.adapters.ZonedDateTimeJsonAdapter
-import okhttp3.OkHttpClient
+import okhttp3.Call
 import org.threeten.bp.Instant
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-object ApiModule : EngelsystemApi {
+object Api : EngelsystemApi {
 
     override fun provideEngelsystemService(
         baseUrl: String,
-        okHttpClient: OkHttpClient
+        callFactory: Call.Factory
     ): EngelsystemService {
-        return createRetrofit(baseUrl, okHttpClient).create(EngelsystemService::class.java)
+        require(baseUrl.isNotEmpty()) { "baseUrl is empty." }
+        return createRetrofit(baseUrl, callFactory).create(EngelsystemService::class.java)
     }
 
     private fun createRetrofit(
         baseUrl: String,
-        okHttpClient: OkHttpClient
+        callFactory: Call.Factory
     ) = Retrofit.Builder()
         .baseUrl(baseUrl)
         .addConverterFactory(MoshiConverterFactory.create(provideMoshiBuilder()))
-        .client(okHttpClient)
+        .callFactory(callFactory)
         .build()
 
     private fun provideMoshiBuilder(): Moshi {

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/ApiModule.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/ApiModule.kt
@@ -20,14 +20,6 @@ object ApiModule : EngelsystemApi {
         return createRetrofit(baseUrl, okHttpClient).create(EngelsystemService::class.java)
     }
 
-    private fun provideMoshiBuilder(): Moshi {
-        return Moshi.Builder()
-            .add(Instant::class.java, InstantJsonAdapter())
-            .add(ZonedDateTime::class.java, ZonedDateTimeJsonAdapter())
-            .add(ZoneOffset::class.java, ZoneOffsetJsonAdapter())
-            .build()
-    }
-
     private fun createRetrofit(
         baseUrl: String,
         okHttpClient: OkHttpClient
@@ -36,5 +28,13 @@ object ApiModule : EngelsystemApi {
         .addConverterFactory(MoshiConverterFactory.create(provideMoshiBuilder()))
         .client(okHttpClient)
         .build()
+
+    private fun provideMoshiBuilder(): Moshi {
+        return Moshi.Builder()
+            .add(Instant::class.java, InstantJsonAdapter())
+            .add(ZonedDateTime::class.java, ZonedDateTimeJsonAdapter())
+            .add(ZoneOffset::class.java, ZoneOffsetJsonAdapter())
+            .build()
+    }
 
 }

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemApi.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemApi.kt
@@ -1,12 +1,12 @@
 package info.metadude.kotlin.library.engelsystem
 
-import okhttp3.OkHttpClient
+import okhttp3.Call
 
 interface EngelsystemApi {
 
     fun provideEngelsystemService(
         baseUrl: String,
-        okHttpClient: OkHttpClient
+        callFactory: Call.Factory,
     ): EngelsystemService
 
 }

--- a/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemService.kt
+++ b/engelsystem-base/src/main/kotlin/info/metadude/kotlin/library/engelsystem/EngelsystemService.kt
@@ -1,7 +1,9 @@
 package info.metadude.kotlin.library.engelsystem
 
 import info.metadude.kotlin.library.engelsystem.models.Shift
+import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -9,8 +11,10 @@ interface EngelsystemService {
 
     @GET("{path}")
     suspend fun getShifts(
+        @Header("If-None-Match") eTag: String,
+        @Header("If-Modified-Since") lastModifiedAt: String,
         @Path("path", encoded = true) path: String,
-        @Query("key") apiKey: String
-    ): List<Shift>
+        @Query("key") apiKey: String,
+    ): Response<List<Shift>>
 
 }

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
@@ -76,7 +76,7 @@ class ProductionApiTest {
             .addNetworkInterceptor(UserAgentInterceptor("engelsystem-base library; ${javaClass.simpleName}"))
             .addNetworkInterceptor(interceptor)
             .build()
-        ApiModule.provideEngelsystemService(BASE_URL, okHttpClient)
+        Api.provideEngelsystemService(BASE_URL, okHttpClient)
     }
 
 }

--- a/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
+++ b/engelsystem-base/src/test/kotlin/info/metadude/kotlin/library/engelsystem/ProductionApiTest.kt
@@ -9,7 +9,6 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.threeten.bp.ZonedDateTime
-import retrofit2.HttpException
 
 class ProductionApiTest {
 
@@ -22,13 +21,25 @@ class ProductionApiTest {
     }
 
     @Test
-    fun `Validates a successful shifts response`() = runTest {
+    fun `getShifts responds successfully`() = runTest {
         try {
-            val shifts = service.getShifts(URL_PART_PATH, VALID_API_KEY)
-            assertThat(shifts).isNotNull()
-            shifts.forEach {
-                assertThat(it).isNotNull()
-                assertShift(it)
+            val response = service.getShifts(
+                eTag = "",
+                lastModifiedAt = "",
+                path = URL_PART_PATH,
+                apiKey = VALID_API_KEY,
+            )
+            when (response.isSuccessful) {
+                true -> {
+                    val shifts = response.body()
+                    assertThat(shifts).isNotNull()
+                    shifts?.forEach {
+                        assertThat(it).isNotNull()
+                        assertShift(it)
+                    }
+                }
+
+                false -> fail("Request failed with code ${response.code()}: ${response.message()}")
             }
         } catch (t: Throwable) {
             fail("Should not throw $t")
@@ -57,15 +68,26 @@ class ProductionApiTest {
     }
 
     @Test
-    fun `Validates a failure shifts response`() = runTest {
+    fun `getShifts throws HTTP exception`() = runTest {
         try {
-            service.getShifts(URL_PART_PATH, INVALID_API_KEY)
-            fail("Request should not succeed.")
-        } catch (e: HttpException) {
-            assertThat(e.message()).isEqualTo("Forbidden")
-            assertThat(e.code()).isEqualTo(403)
-            assertThat(e.response()!!.body()).isNull()
-            assertThat(e.response()!!.errorBody()).isNotNull()
+            val response = service.getShifts(
+                eTag = "",
+                lastModifiedAt = "",
+                path = URL_PART_PATH,
+                apiKey = INVALID_API_KEY,
+            )
+            when (response.isSuccessful) {
+                false -> {
+                    assertThat(response.code()).isEqualTo(403)
+                    assertThat(response.message()).isEqualTo("Forbidden")
+                    assertThat(response.body()).isNull()
+                    assertThat(response.errorBody()).isNotNull()
+                }
+
+                true -> fail("Request should not succeed.")
+            }
+        } catch (t: Throwable) {
+            fail("Should not throw $t")
         }
     }
 


### PR DESCRIPTION
# Context
+ This **breaking change** allows to set the HTTP headers `If-None-Match` and `If-Modified-Since` at a request and get the HTTP headers `ETag` and `Last-Modified` from a response. This allows to reduce the transferred data to a minimum due to the support of [`HTTP 304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304).

# Description
+ Let `EngelsystemService#getShifts` return `Response<List<Shift>>`.    
  + Add `eTag` and `lastModifiedAt` parameters.
  + Expose `retrofit2.Response` in library API.
+ Refine `Api` in general.
  + Rename `ApiModule` to `Api`.
  + Change `Api#provideEngelsystemService` parameter from `okHttpClient: OkHttpClient` to `callFactory: Call.Factory`.
  + Require `baseUrl` parameter in `Api#provideEngelsystemService` not to be empty string.

# Related
- #13 